### PR TITLE
Created Alpine Docker image for git-secret'ing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ssm-parameter-store
 We want to be able to version control, and review private (and potentially secret) data. e.g. the private data stored in SSM's parameter store.  
 
-This repo is a test using `git-secret` and some identically formatted sample data, in order to achieve this.  The data is encrypted, using a keyring containing the current team members public keys.  This currently allows these members (`git secret whoknows`) to decrypt, edit, and encrypt the data we intend to be private(secret).
+This repo is a test using [git-secret](https://git-secret.io) and some identically formatted sample data, in order to achieve this.  The data is encrypted, using a keyring containing the current team members public keys.  This currently allows these members (`git secret whoknows`) to decrypt, edit, and encrypt the data we intend to be private(secret).
 
 
 ## Required

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Private data stored in SSM's parameter store
 
 
-# Required
+## Required
 
 `git-secret` which can be obtained by:  
 `brew install git-secret`  
@@ -15,3 +15,22 @@ You can make changes and then reseal with:
 
 the `-d` deletes the plain text version of the file you edited.
 
+## Secret-Builder
+Locally built & ran Docker container, that improves the usage of this format for some users.  
+
+### Usage
+
+```
+docker build -t dwpdigital/secret-builder:0.0.1 .
+```  
+
+```
+docker run -it -v ~/.ssh/id_rsa:/root/.ssh/id_rsa -v ~/.ssh/id_rsa.pub:/root/.ssh/id_rsa.pub -v ~/.gnupg/:/root/.gnupg -e GIT_USERNAME='Your Name' -e GIT_EMAIL=your.name@email.com dwpdigital/secret-builder:0.0.2
+```  
+
+```
+git clone git@github.com:dwp/ssm-parameter-store.git
+cd ssm-parameter-store
+```  
+
+`reveal` and `hide` commands will work as above.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ssm-parameter-store
-Private data stored in SSM's parameter store
+We want to be able to version control, and review private (and potentially secret) data. e.g. the private data stored in SSM's parameter store.  
+
+This repo is a test using `git-secret` and some identically formatted sample data, in order to achieve this.  The data is encrypted, using a keyring containing the current team members public keys.  This currently allows these members (`git secret whoknows`) to decrypt, edit, and encrypt the data we intend to be private(secret).
 
 
 ## Required

--- a/secret-builder/Dockerfile
+++ b/secret-builder/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.11 as BASE
+
+RUN echo @testing http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
+RUN cat /etc/apk/repositories
+RUN apk update
+
+FROM BASE as SECRET
+
+RUN apk add bash \
+    openssh-client \
+    gawk \
+    git \
+    git-secret@testing
+
+FROM SECRET
+
+COPY git-setup.sh .
+RUN chmod +x git-setup.sh
+ENTRYPOINT [ "./git-setup.sh" ]

--- a/secret-builder/Dockerfile
+++ b/secret-builder/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.11 as BASE
 
 RUN echo @testing http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
-RUN cat /etc/apk/repositories
+
 RUN apk update
 
 FROM BASE as SECRET

--- a/secret-builder/git-setup.sh
+++ b/secret-builder/git-setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+git config --global user.name "$GIT_USERNAME" \
+&& git config --global user.email "$GIT_EMAIL"
+
+/bin/bash


### PR DESCRIPTION
Currently there is an issue with UC Macs causing installs from `brew` or plain `make install` to last a very long time.  This means setup and usage of `git-secrets` is a pain.
This container allows a user to circumvent that pain with a locally ran instance of `git-secrets`, that bundles their ssh & gpg keys on run.