### PR TITLE
Fix git cloning over HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ docker build -t dwpdigital/secret-builder:0.0.1 .
 ```  
 
 ```
-docker run -it -v ~/.ssh/id_rsa:/root/.ssh/id_rsa -v ~/.ssh/id_rsa.pub:/root/.ssh/id_rsa.pub -v ~/.gnupg/:/root/.gnupg -e GIT_USERNAME='Your Name' -e GIT_EMAIL=your.name@email.com dwpdigital/secret-builder:0.0.2
+docker run -it -v ~/.ssh/id_rsa:/root/.ssh/id_rsa -v ~/.ssh/id_rsa.pub:/root/.ssh/id_rsa.pub -v ~/.gnupg/:/root/.gnupg -e GIT_USERNAME='Your Name' -e GIT_EMAIL=your.name@email.com dwpdigital/secret-builder:0.0.1
 ```  
 
 ```
-git clone git@github.com:dwp/ssm-parameter-store.git
+git clone https://github.com/dwp/ssm-parameter-store.git
 cd ssm-parameter-store
 ```  
 

--- a/secret-builder/Dockerfile
+++ b/secret-builder/Dockerfile
@@ -17,7 +17,7 @@ RUN apk add bash \
 
 FROM SECRET as CERTS
 RUN echo | openssl s_client -showcerts -servername server -connect github.com:443 > /usr/local/share/ca-certificates/cacert.pem \
-&& update-ca-certificates 2>&1 > /dev/null
+    && update-ca-certificates 2>&1 > /dev/null
 
 FROM CERTS
 

--- a/secret-builder/Dockerfile
+++ b/secret-builder/Dockerfile
@@ -10,9 +10,16 @@ RUN apk add bash \
     openssh-client \
     gawk \
     git \
-    git-secret@testing
+    git-secret@testing \
+    curl \
+    openssl \
+    ca-certificates
 
-FROM SECRET
+FROM SECRET as CERTS
+RUN echo | openssl s_client -showcerts -servername server -connect github.com:443 > /usr/local/share/ca-certificates/cacert.pem \
+&& update-ca-certificates 2>&1 > /dev/null
+
+FROM CERTS
 
 COPY git-setup.sh .
 RUN chmod +x git-setup.sh


### PR DESCRIPTION
UC Macs can't clone over SSH, and have MITM certificates to deal with
when cloning over HTTPS. Pull those down during the container build
process.